### PR TITLE
Less permissive installs

### DIFF
--- a/meta-thistle-update-client/recipes-client/embedded-client/embedded-client_0.1.12.bb
+++ b/meta-thistle-update-client/recipes-client/embedded-client/embedded-client_0.1.12.bb
@@ -13,5 +13,5 @@ INSANE_SKIP:${PN} += "already-stripped"
 
 do_install() {
     install -d ${D}${bindir}
-    install -m 0777 ${WORKDIR}/tuc ${D}${bindir}/tuc
+    install -m 0755 ${WORKDIR}/tuc ${D}${bindir}/tuc
 }

--- a/meta-trust-m/recipes-client/trust-m/trust-m_0.1.0.2.bb
+++ b/meta-trust-m/recipes-client/trust-m/trust-m_0.1.0.2.bb
@@ -20,9 +20,9 @@ do_compile() {
 
 do_install() {
    install -d ${D}${libdir}
-   install -m 0777 ${S}/bin/libtrustm.so ${D}${libdir}
+   install -m 0755 ${S}/bin/libtrustm.so ${D}${libdir}
    install -d ${D}${bindir}
-   install -m 0777 ${S}/bin/trustm_* ${D}${bindir}
+   install -m 0755 ${S}/bin/trustm_* ${D}${bindir}
 }
 
 FILES_SOLIBSDEV = ""


### PR DESCRIPTION
Make installed executables and libraries not group and world writeable.

Explicitly setting permission `0755` for these files is likely superfluous, but explicit is better than implicit.